### PR TITLE
Hide related videos in YouTube embeds

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     {
       "run_at": "document_start",
       "matches": ["https://www.youtube.com/*"],
-      "css": ["styles.css"]
+      "css": ["styles.css"],
+      "all_frames": true
     }
   ],
   "manifest_version": 2


### PR DESCRIPTION
Setting `"all_frames": true` injects the extension's CSS into all frames on the page, not just the topmost one. This change hides the related videos shown at the end of a YouTube video on any page, not just on youtube.com.

Docs for the `all_frames` field:
https://developer.chrome.com/extensions/content_scripts#frames

Thanks for making this extension!